### PR TITLE
Correct process_noise_matrix for baseline components

### DIFF
--- a/src/canari/component/baseline_component.py
+++ b/src/canari/component/baseline_component.py
@@ -151,7 +151,7 @@ class LocalTrend(BaseComponent):
 
     def initialize_process_noise_matrix(self):
         self._process_noise_matrix = self.std_error**2 * np.array(
-            [[1 / 3, 1 / 2], [1 / 2, 1]]
+            [[1 / 4, 1 / 2], [1 / 2, 1]]
         )
 
     def initialize_mu_states(self):
@@ -233,7 +233,7 @@ class LocalAcceleration(BaseComponent):
 
     def initialize_process_noise_matrix(self):
         self._process_noise_matrix = self.std_error**2 * np.array(
-            [[1 / 20, 1 / 8, 1 / 6], [1 / 8, 1 / 3, 0.5], [1 / 6, 0.5, 1]]
+            [[1 / 4, 0.5, 0.5], [0.5, 1, 1], [0.5, 1, 1]]
         )
 
     def initialize_mu_states(self):


### PR DESCRIPTION
# Description
This PR corrects the `process_noise_matrix` for `local_trend` and `local_acceleration` components following the matrices in the book. This is because the current matrices used are from the old version of the book.

 # Changes made
`baseline_component.py`

# Notes for Reviewers
N/A. 