### PR TITLE
Bugfix/Add epsilon cal. transition likelihood

### DIFF
--- a/docs/examples/anomaly_detection.ipynb
+++ b/docs/examples/anomaly_detection.ipynb
@@ -4,7 +4,7 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "# Anomaly detection using the swithing Kalman filter\n",
+                "# Anomaly detection using the switching Kalman filter\n",
                 "This tutorial example presents how to detect anomalies that take the form of change points. The model relies on the switching Kalman filter (SKF) that estimates the probability of the local trend regime versus a local acceleration regime, whereas a high probability for the later indicates the presence of a change point in a time series.\n",
                 "\n",
                 "The calibration of the LSTM neural network relies on the raw traning set that is deemed to be stationnary and the SKF hyperparameters are estimated using synthetic anomalies that are added on the raw traning set. \n",

--- a/examples/tutorial/anomaly_detection.ipynb
+++ b/examples/tutorial/anomaly_detection.ipynb
@@ -4,7 +4,7 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "# Anomaly detection using the swithing Kalman filter\n",
+                "# Anomaly detection using the switching Kalman filter\n",
                 "This tutorial example presents how to detect anomalies that take the form of change points. The model relies on the switching Kalman filter (SKF) that estimates the probability of the local trend regime versus a local acceleration regime, whereas a high probability for the later indicates the presence of a change point in a time series.\n",
                 "\n",
                 "The calibration of the LSTM neural network relies on the raw traning set that is deemed to be stationnary and the SKF hyperparameters are estimated using synthetic anomalies that are added on the raw traning set. \n",

--- a/src/canari/model_optimizer.py
+++ b/src/canari/model_optimizer.py
@@ -102,7 +102,7 @@ class ModelOptimizer:
                 np.prod([len(v) for v in self._param_space.values()])
             )
         else:
-            sampler = optuna.samplers.TPESampler(seed=42)
+            sampler = optuna.samplers.TPESampler()
 
         print("-----")
         print("Model optimization starts")

--- a/src/canari/skf.py
+++ b/src/canari/skf.py
@@ -439,6 +439,7 @@ class SKF:
             dict[str, float]: Likelihood for each transition key.
         """
 
+        epsilon = 1e-30
         transition_likelihood = self._transition()
         if np.isnan(obs):
             for transit in transition_likelihood:
@@ -466,12 +467,15 @@ class SKF:
                     )
             else:
                 for transit in transition_likelihood:
-                    transition_likelihood[transit] = np.exp(
-                        metric.log_likelihood(
-                            mu_pred_transit[transit],
-                            obs,
-                            var_pred_transit[transit] ** 0.5,
-                        )
+                    transition_likelihood[transit] = np.maximum(
+                        np.exp(
+                            metric.log_likelihood(
+                                mu_pred_transit[transit],
+                                obs,
+                                var_pred_transit[transit] ** 0.5,
+                            )
+                        ),
+                        epsilon,
                     )
         return transition_likelihood
 

--- a/src/canari/skf_optimizer.py
+++ b/src/canari/skf_optimizer.py
@@ -150,7 +150,7 @@ class SKFOptimizer:
                 np.prod([len(v) for v in self._param_space.values()])
             )
         else:
-            sampler = optuna.samplers.TPESampler(seed=42)
+            sampler = optuna.samplers.TPESampler()
             self._num_optimization_trial = self._num_optimization_trial
 
         print("-----")


### PR DESCRIPTION
# Description
This PR fixes a bug for numerical instability in SKF, that is, when the transition likelihood matrix has zero values, replace zero with `epsilon=1e-30`. 
Without fixing this bug, when the transition likelihood matrix takes zero-values, the analysis will fail, giving Nan values.

# Changes made
`skf._compute_transition_likelihood`

# Note for reviewers
N/A
