### PR TITLE
Feature/lstm_embedding

### DIFF
--- a/src/canari/common.py
+++ b/src/canari/common.py
@@ -4,7 +4,7 @@ Utility functions that are used in mulitple classes.
 
 from typing import Tuple, Optional
 import numpy as np
-from canari.data_struct import LstmOutputHistory
+from canari.data_struct import LstmOutputHistory, LstmEmbedding
 from math import erf
 
 
@@ -218,6 +218,7 @@ def prepare_lstm_input(
     lstm_output_history: LstmOutputHistory,
     input_covariates: np.ndarray,
     var_input_covariates: Optional[np.ndarray] = None,
+    lstm_embedding: Optional[LstmEmbedding] = None,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """
     Prepare LSTM input by concatenating past LSTM outputs with current input covariates.
@@ -226,6 +227,7 @@ def prepare_lstm_input(
         lstm_output_history (LstmOutputHistory): Historical LSTM mean/variance.
         input_covariates (np.ndarray): Means for input covariates.
         var_input_covariates (Optional[np.ndarray]): Variances for input covariates.
+        lstm_embedding (Optional[LstmEmbedding]): LSTM embedding mean/variance.
 
     Returns:
         Tuple[np.ndarray, np.ndarray]: LSTM input means and variances.
@@ -238,6 +240,9 @@ def prepare_lstm_input(
         var_lstm_input = np.concatenate(
             (lstm_output_history.var, np.zeros(len(input_covariates)))
         )
+    if lstm_embedding is not None:
+        mu_lstm_input = np.concatenate((mu_lstm_input, lstm_embedding.mu))
+        var_lstm_input = np.concatenate((var_lstm_input, lstm_embedding.var))
     return mu_lstm_input, var_lstm_input
 
 

--- a/src/canari/common.py
+++ b/src/canari/common.py
@@ -240,7 +240,7 @@ def prepare_lstm_input(
         var_lstm_input = np.concatenate(
             (lstm_output_history.var, np.zeros(len(input_covariates)))
         )
-    if lstm_embedding is not None:
+    if lstm_embedding is not None and getattr(lstm_embedding, "length", 0) > 0:
         mu_lstm_input = np.concatenate((mu_lstm_input, lstm_embedding.mu))
         var_lstm_input = np.concatenate((var_lstm_input, lstm_embedding.var))
     return mu_lstm_input, var_lstm_input

--- a/src/canari/component/lstm_component.py
+++ b/src/canari/component/lstm_component.py
@@ -118,7 +118,7 @@ class LstmNetwork(BaseComponent):
         self.smoother = smoother
         self.model_noise = model_noise
         self.num_output = 2 * num_output if self.model_noise else num_output
-        self.embed_len = embed_len if embedding is None else embedding[0].shape[1]
+        self.embed_len = embed_len if embedding is None else embedding[0].flatten().shape[0]
         self.embedding = embedding
         super().__init__()
 
@@ -240,6 +240,7 @@ class LstmNetwork(BaseComponent):
         lstm_network.lstm_look_back_len = self.look_back_len
         lstm_network.lstm_infer_len = self.infer_len
         lstm_network.model_noise = self.model_noise
+        lstm_network.embed_len = self.embed_len
         lstm_network.num_samples = 1  # dummy intialization until otherwise specified
         if self.device == "cpu":
             lstm_network.set_threads(self.num_thread)

--- a/src/canari/component/lstm_component.py
+++ b/src/canari/component/lstm_component.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 import numpy as np
 import pytagi
 from pytagi.nn import Sequential, LSTM, Linear, SLSTM, SLinear
@@ -98,6 +98,8 @@ class LstmNetwork(BaseComponent):
         var_states: Optional[list[float]] = None,
         smoother: Optional[bool] = True,
         model_noise: Optional[bool] = False,
+        embed_len: Optional[int] = 0,
+        embedding: Optional[Tuple[np.ndarray, np.ndarray]] = None,
     ):
         self.std_error = std_error
         self.num_layer = num_layer
@@ -116,6 +118,8 @@ class LstmNetwork(BaseComponent):
         self.smoother = smoother
         self.model_noise = model_noise
         self.num_output = 2 * num_output if self.model_noise else num_output
+        self.embed_len = embed_len if embedding is None else embedding[0].shape[1]
+        self.embedding = embedding
         super().__init__()
 
     def initialize_component_name(self):
@@ -188,7 +192,7 @@ class LstmNetwork(BaseComponent):
         if self.smoother:
             layers.append(
                 SLSTM(
-                    self.num_features + self.look_back_len - 1,
+                    self.num_features + self.look_back_len + self.embed_len - 1,
                     self.num_hidden_unit[0],
                     1,
                     gain_weight=self.gain_weight,
@@ -212,7 +216,7 @@ class LstmNetwork(BaseComponent):
         else:
             layers.append(
                 LSTM(
-                    self.num_features + self.look_back_len - 1,
+                    self.num_features + self.look_back_len + self.embed_len - 1,
                     self.num_hidden_unit[0],
                     1,
                     gain_weight=self.gain_weight,
@@ -253,6 +257,9 @@ class LstmNetwork(BaseComponent):
             lstm_network.smooth = True
         else:
             lstm_network.smooth = False
+
+        if self.embed_len > 0:
+            lstm_network.input_state_update = True
 
         if self.load_lstm_net:
             lstm_network.load(filename=self.load_lstm_net)

--- a/src/canari/data_struct.py
+++ b/src/canari/data_struct.py
@@ -247,30 +247,60 @@ class LstmEmbedding:
     Stores the current LSTM embedding mean and variance vectors.
 
     Attributes:
-        mu (np.ndarray): Mean of the embedding with shape (1, embedding_dim).
-        var (np.ndarray): Variance of the embedding with shape (1, embedding_dim).
+        mu (np.ndarray): Mean of the embedding with shape (embedding_dim,).
+        var (np.ndarray): Variance of the embedding with shape (embedding_dim,).
+        length (int): Number of embedding features currently tracked.
     """
 
     mu: np.ndarray = field(init=False)
     var: np.ndarray = field(init=False)
+    length: int = field(init=False, default=0)
 
     def initialize(self, embedding_len: int):
         """
         Initialize the mean and variance of the embedding vector.
 
-        The mean is sampled from a standard normal distribution and the variance
-        is initialized to ones. Both arrays have shape (1, embedding_len).
+        The mean is initialized to zeros and the variance to ones. Both arrays
+        have shape (embedding_len,).
 
         Args:
             embedding_len (int): Length of the LSTM embedding.
         """
-        self.mu = np.random.normal(0, 1, (1, embedding_len)).astype(np.float32)
-        self.var = np.ones((1, embedding_len), dtype=np.float32)
+        if embedding_len <= 0:
+            raise ValueError("Embedding length must be a positive integer.")
+
+        self.mu = np.random.normal(loc=0.0, scale=1.0, size=embedding_len).astype(
+            np.float32
+        )
+        self.var = np.ones(embedding_len, dtype=np.float32)
+        self.length = embedding_len
+
+    def set_values(
+        self,
+        mu: np.ndarray,
+        var: np.ndarray,
+    ):
+        """
+        Explicitly set the embedding mean and variance arrays.
+
+        Args:
+            mu (np.ndarray): Mean of the embedding.
+            var (np.ndarray): Variance of the embedding.
+        """
+        prepared_mu = self._prepare_vector(mu, "mu")
+        prepared_var = self._prepare_vector(var, "var")
+        if prepared_mu.shape != prepared_var.shape:
+            raise ValueError("Mean and variance must share the same shape.")
+
+        self.mu = prepared_mu
+        self.var = prepared_var
+        self.length = self.mu.size
 
     def update(
         self,
         delta_mu: np.ndarray,
         delta_var: np.ndarray,
+        min_variance: float = 1e-6,
     ):
         """
         Update the LSTM embedding mean and variance in place.
@@ -278,18 +308,34 @@ class LstmEmbedding:
         Args:
             delta_mu (np.ndarray): Update term applied to the current mean.
             delta_var (np.ndarray): Update term applied to the current variance.
+            min_variance (float): Lower bound applied to the variance for stability.
         """
-        self.mu += delta_mu * self.mu
-        self.var += self.var * delta_var * self.var
+        if self.length == 0:
+            raise RuntimeError("LSTM embedding must be initialized before updating.")
 
-    def __getitem__(self) -> tuple[np.ndarray, np.ndarray]:
+        delta_mu = self._prepare_vector(delta_mu, "delta_mu")
+        delta_var = self._prepare_vector(delta_var, "delta_var")
+
+        if delta_mu.shape != self.mu.shape or delta_var.shape != self.var.shape:
+            raise ValueError("Update terms must match embedding shape.")
+
+        self.mu = self.mu + delta_mu
+        self.var = np.maximum(
+            self.var + delta_var, np.full_like(self.var, min_variance)
+        )
+
+    def as_tuple(self) -> tuple[np.ndarray, np.ndarray]:
         """
         Get the mean and variance of the LSTM embedding.
 
         Returns:
             tuple[np.ndarray, np.ndarray]: Mean and variance arrays of the LSTM embedding.
         """
-        return self.mu, self.var
+
+        return self.mu.copy(), self.var.copy()
+
+    def __getitem__(self) -> tuple[np.ndarray, np.ndarray]:
+        return self.as_tuple()
 
     def __setitem__(self, value: tuple[np.ndarray, np.ndarray]):
         """
@@ -298,4 +344,30 @@ class LstmEmbedding:
         Args:
             value (tuple[np.ndarray, np.ndarray]): New mean and variance arrays to set.
         """
-        self.mu, self.var = value
+        self.set_values(*value)
+
+    def _prepare_vector(self, array: np.ndarray, name: str) -> np.ndarray:
+        """
+        Convert an input array to a 1D float32 vector with the expected length.
+        """
+        arr = np.asarray(array, dtype=np.float32)
+        if arr.ndim > 2:
+            raise ValueError(f"Embedding {name} must be 1D or a single-row 2D array.")
+
+        if arr.ndim == 2:
+            if arr.shape[0] != 1:
+                raise ValueError(
+                    f"Embedding {name} 2D arrays must have shape (1, embedding_len)."
+                )
+            arr = arr.squeeze(axis=0)
+
+        if arr.ndim == 0:
+            arr = arr.reshape(1)
+
+        if self.length and arr.size != self.length:
+            raise ValueError(
+                f"Embedding {name} length mismatch: expected {self.length}, "
+                f"got {arr.size}."
+            )
+
+        return arr.copy()

--- a/src/canari/data_struct.py
+++ b/src/canari/data_struct.py
@@ -239,3 +239,63 @@ class OutputHistory:
 
         self.mu.append(mu.item())
         self.var.append(var.item())
+
+
+@dataclass
+class LstmEmbedding:
+    """
+    Stores the current LSTM embedding mean and variance vectors.
+
+    Attributes:
+        mu (np.ndarray): Mean of the embedding with shape (1, embedding_dim).
+        var (np.ndarray): Variance of the embedding with shape (1, embedding_dim).
+    """
+
+    mu: np.ndarray = field(init=False)
+    var: np.ndarray = field(init=False)
+
+    def initialize(self, embedding_len: int):
+        """
+        Initialize the mean and variance of the embedding vector.
+
+        The mean is sampled from a standard normal distribution and the variance
+        is initialized to ones. Both arrays have shape (1, embedding_len).
+
+        Args:
+            embedding_len (int): Length of the LSTM embedding.
+        """
+        self.mu = np.random.normal(0, 1, (1, embedding_len)).astype(np.float32)
+        self.var = np.ones((1, embedding_len), dtype=np.float32)
+
+    def update(
+        self,
+        delta_mu: np.ndarray,
+        delta_var: np.ndarray,
+    ):
+        """
+        Update the LSTM embedding mean and variance in place.
+
+        Args:
+            delta_mu (np.ndarray): Update term applied to the current mean.
+            delta_var (np.ndarray): Update term applied to the current variance.
+        """
+        self.mu += delta_mu * self.mu
+        self.var += self.var * delta_var * self.var
+
+    def __getitem__(self) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Get the mean and variance of the LSTM embedding.
+
+        Returns:
+            tuple[np.ndarray, np.ndarray]: Mean and variance arrays of the LSTM embedding.
+        """
+        return self.mu, self.var
+
+    def __setitem__(self, value: tuple[np.ndarray, np.ndarray]):
+        """
+        Set the mean and variance of the LSTM embedding.
+
+        Args:
+            value (tuple[np.ndarray, np.ndarray]): New mean and variance arrays to set.
+        """
+        self.mu, self.var = value

--- a/src/canari/model.py
+++ b/src/canari/model.py
@@ -29,7 +29,12 @@ from pytagi import Normalizer as normalizer
 from pytagi.nn import OutputUpdater
 from canari.component.base_component import BaseComponent
 from canari import common
-from canari.data_struct import LstmOutputHistory, StatesHistory, OutputHistory
+from canari.data_struct import (
+    LstmOutputHistory,
+    StatesHistory,
+    OutputHistory,
+    LstmEmbedding,
+)
 from canari.common import GMA
 from canari.data_process import DataProcess
 
@@ -189,6 +194,7 @@ class Model:
         self.lstm_net = None
         self.lstm_output_history = LstmOutputHistory()
         self.lstm_states_history = []
+        self.lstm_embedding = LstmEmbedding()
 
         # Autoregression-related attributes
         self.mu_W2bar = None
@@ -293,6 +299,11 @@ class Model:
         if lstm_component:
             self.lstm_net = lstm_component.initialize_lstm_network()
             self.lstm_output_history.initialize(self.lstm_net.lstm_look_back_len)
+            if lstm_component.embed_len > 0:
+                if lstm_component.embedding is None:
+                    self.lstm_embedding.initialize(lstm_component.embed_len)
+                else:
+                    self.lstm_embedding.embedding = lstm_component.embedding
 
     def _initialize_autoregression(self):
         """

--- a/test/test_embedding.py
+++ b/test/test_embedding.py
@@ -1,0 +1,142 @@
+import os
+import pandas as pd
+import numpy as np
+from canari import DataProcess, Model
+from canari.component import LocalTrend, LstmNetwork, WhiteNoise
+import pytest
+from typing import Any
+
+BASE_DIR = os.path.dirname(__file__)
+
+
+def model_test_runner(model: Model, run_mode: str) -> Any:
+    """
+    Run training SSM+LSTM model with embedding functionality
+    """
+
+    output_col = [0]
+
+    # Read data
+    data_file = os.path.join(BASE_DIR, "../data/toy_time_series/sine.csv")
+    df_raw = pd.read_csv(data_file, skiprows=1, delimiter=",", header=None)
+    linear_space = np.linspace(0, 2, num=len(df_raw))
+    df_raw = df_raw.add(linear_space, axis=0)
+    data_file_time = os.path.join(BASE_DIR, "../data/toy_time_series/sine_datetime.csv")
+    time_series = pd.read_csv(data_file_time, skiprows=1, delimiter=",", header=None)
+    time_series = pd.to_datetime(time_series[0])
+    df_raw.index = time_series
+
+    # Data processing
+    data_processor = DataProcess(
+        data=df_raw,
+        train_split=0.8,
+        validation_split=0.2,
+        output_col=output_col,
+    )
+    train_data, validation_data, _, _ = data_processor.get_splits()
+
+    # Initialize model
+    model.auto_initialize_baseline_states(train_data["y"][0:24])
+    num_epoch = 10
+    for epoch in range(num_epoch):
+        (mu_validation_preds, std_validation_preds, states) = model.lstm_train(
+            train_data=train_data,
+            validation_data=validation_data,
+        )
+
+    if run_mode == "fixed_embedding":
+        return model.lstm_embedding
+    elif run_mode == "update_embedding":
+        # train for one more epoch to update embedding
+        model.filter(train_data, train_lstm=True, update_embedding=True)
+        return model.lstm_embedding
+
+
+@pytest.mark.parametrize("run_mode", [("fixed_embedding"), ("update_embedding")])
+@pytest.mark.parametrize("embed_mode", [("set_embedding"), ("init_embedding")])
+@pytest.mark.parametrize("smoother", [(False), (True)], ids=["LSTM", "SLSTM"])
+def test_model_embedding(embed_mode, smoother, run_mode):
+    "Test embedding functionality in LSTM model"
+
+    if embed_mode == "set_embedding":
+
+        # Define embedding
+        embed_len = 15
+        embed_mu = (
+            np.sin(np.linspace(0, 2 * np.pi, embed_len))
+            .reshape(1, -1)
+            .astype(np.float32)
+        )
+        embed_var = (np.ones_like(embed_mu) * 0.1).astype(np.float32)
+
+        model = Model(
+            LocalTrend(),
+            LstmNetwork(
+                look_back_len=19,
+                num_features=1,
+                num_layer=1,
+                infer_len=24,
+                num_hidden_unit=50,
+                device="cpu",
+                manual_seed=1,
+                smoother=smoother,
+                embedding=(embed_mu, embed_var),
+            ),
+            WhiteNoise(std_error=0.003),
+        )
+    elif embed_mode == "init_embedding":
+
+        model = Model(
+            LocalTrend(),
+            LstmNetwork(
+                look_back_len=19,
+                num_features=1,
+                num_layer=1,
+                infer_len=24,
+                num_hidden_unit=50,
+                device="cpu",
+                manual_seed=1,
+                smoother=smoother,
+                embed_len=15,
+            ),
+            WhiteNoise(std_error=0.003),
+        )
+    else:
+        raise ValueError("Invalid embed_mode")
+
+    lstm_embedding = model_test_runner(model, run_mode)
+
+    assert lstm_embedding is not None
+    assert lstm_embedding.length == 15
+
+    if embed_mode == "set_embedding":
+        if run_mode == "fixed_embedding":
+            np.testing.assert_array_almost_equal(
+                lstm_embedding.mu.reshape(1, -1),
+                embed_mu,
+                decimal=5,
+                err_msg="LSTM embedding mean does not match the set embedding mean",
+            )
+            np.testing.assert_array_almost_equal(
+                lstm_embedding.var.reshape(1, -1),
+                embed_var,
+                decimal=5,
+                err_msg="LSTM embedding variance does not match the set embedding variance",
+            )
+        elif run_mode == "update_embedding":
+            np.testing.assert_raises(
+                AssertionError,
+                np.testing.assert_array_almost_equal,
+                lstm_embedding.mu.reshape(1, -1),
+                embed_mu,
+                decimal=5,
+                err_msg="LSTM embedding mean should have been updated and not match the set embedding mean",
+            )
+            np.testing.assert_raises(
+                AssertionError,
+                np.testing.assert_array_almost_equal,
+                lstm_embedding.var.reshape(1, -1),
+                embed_var,
+                decimal=5,
+                err_msg="LSTM embedding variance should have been updated and not match the set embedding variance",
+            )


### PR DESCRIPTION
## Description

This PR allows users to handle learnable embeddings in the LSTM input. Users can randomly initialize, manually set, and further update an input embedding.

## Changes Made

- Added a new data class called `LstmEmbedding`.
- Allowed embeddings to be either be randomly initialized by providing an embedding length in the LSTM component.
- Added the capability to hard set the embedding through the LSTM component. The user can specify a previously learned input embedding through the LSTM component.
- By default the embedding will not be updated when filtering unless otherwise specified by the used though setting `update_embed = True`. Currently calling `lstm_train()` also defaults to not updating the embedding.
- I have added a unit-test to test the different functionalities of the input embedding.

## Checklist

- [x] I have followed the project's coding conventions and style guidelines.
- [x] I have updated or added documentation where necessary.
- [x] I have rebased my branch onto the latest `main` (or relevant) branch.
- [x] I have verified that no sensitive data, plots, or files are included.
- [ ] I have run all previous examples successfully, with no errors.
- [x] I have tested my changes locally using the following commands/tests:

```shell
pytest
```

## Notes for Reviewers
I still need to add a toy example for embeddings.
