### PR TITLE
Fix/detect synthetic anomaly

### DIFF
--- a/examples/benchmark/BM_2step_optim.py
+++ b/examples/benchmark/BM_2step_optim.py
@@ -143,7 +143,7 @@ def main(
             skf.save_initial_states()
 
             num_anomaly = 50
-            detection_rate, false_rate, _ = skf.detect_synthetic_anomaly(
+            detection_rate, num_false_alarm = skf.detect_synthetic_anomaly(
                 data=train_data,
                 num_anomaly=num_anomaly,
                 slope_anomaly=skf_param_space["slope"] / 52,
@@ -154,7 +154,7 @@ def main(
                 - data_processor.data.index[data_processor.train_start]
             ).days / 365.25
 
-            false_rate_yearly = false_rate / data_len_year
+            false_rate_yearly = num_false_alarm / data_len_year
             metric_optim = skf.objective(
                 detection_rate, false_rate_yearly, skf_param_space["slope"]
             )

--- a/examples/benchmark/BM_cdf_obj.py
+++ b/examples/benchmark/BM_cdf_obj.py
@@ -129,12 +129,10 @@ def main(
             skf.save_initial_states()
 
             num_anomaly = 50
-            detection_rate, false_rate, false_alarm_train = (
-                skf.detect_synthetic_anomaly(
-                    data=train_data,
-                    num_anomaly=num_anomaly,
-                    slope_anomaly=param["slope"] / 52,
-                )
+            detection_rate, num_false_alarm = skf.detect_synthetic_anomaly(
+                data=train_data,
+                num_anomaly=num_anomaly,
+                slope_anomaly=param["slope"] / 52,
             )
 
             data_len_year = (
@@ -142,7 +140,7 @@ def main(
                 - data_processor.data.index[data_processor.train_start]
             ).days / 365.25
 
-            false_rate_yearly = false_rate / data_len_year
+            false_rate_yearly = num_false_alarm / data_len_year
             metric_optim = skf.objective(
                 detection_rate, false_rate_yearly, param["slope"]
             )

--- a/examples/benchmark/BM_cdf_obj_fix_skf_param.py
+++ b/examples/benchmark/BM_cdf_obj_fix_skf_param.py
@@ -127,12 +127,10 @@ def main(
             skf.save_initial_states()
 
             num_anomaly = 50
-            detection_rate, false_rate, false_alarm_train = (
-                skf.detect_synthetic_anomaly(
-                    data=train_data,
-                    num_anomaly=num_anomaly,
-                    slope_anomaly=param["slope"] / 52,
-                )
+            detection_rate, num_false_alarm = skf.detect_synthetic_anomaly(
+                data=train_data,
+                num_anomaly=num_anomaly,
+                slope_anomaly=param["slope"] / 52,
             )
 
             data_len_year = (
@@ -140,7 +138,7 @@ def main(
                 - data_processor.data.index[data_processor.train_start]
             ).days / 365.25
 
-            false_rate_yearly = false_rate / data_len_year
+            false_rate_yearly = num_false_alarm / data_len_year
             metric_optim = skf.objective(
                 detection_rate, false_rate_yearly, param["slope"]
             )

--- a/src/canari/model.py
+++ b/src/canari/model.py
@@ -1805,8 +1805,10 @@ class Model:
 
         if self.lstm_net and self.lstm_net.smooth and self.lstm_net.num_samples > 1:
             mu_zo_smooth, var_zo_smooth = self.lstm_net.smoother()
-            mu_sequence = mu_zo_smooth[0,: self.lstm_net.lstm_infer_len].flatten()
-            var_sequence = var_zo_smooth[0,: self.lstm_net.lstm_infer_len].flatten()
+            mu_zo_smooth = mu_zo_smooth.flatten()
+            var_zo_smooth = var_zo_smooth.flatten()
+            mu_sequence = mu_zo_smooth[: self.lstm_net.lstm_infer_len]
+            var_sequence = var_zo_smooth[: self.lstm_net.lstm_infer_len]
             mu_sequence = mu_sequence[-self.lstm_net.lstm_look_back_len :]
             var_sequence = var_sequence[-self.lstm_net.lstm_look_back_len :]
             self.lstm_output_history.mu = mu_sequence

--- a/src/canari/model.py
+++ b/src/canari/model.py
@@ -1805,8 +1805,8 @@ class Model:
 
         if self.lstm_net and self.lstm_net.smooth and self.lstm_net.num_samples > 1:
             mu_zo_smooth, var_zo_smooth = self.lstm_net.smoother()
-            mu_sequence = mu_zo_smooth[: self.lstm_net.lstm_infer_len]
-            var_sequence = var_zo_smooth[: self.lstm_net.lstm_infer_len]
+            mu_sequence = mu_zo_smooth[:,: self.lstm_net.lstm_infer_len].flatten()
+            var_sequence = var_zo_smooth[:,: self.lstm_net.lstm_infer_len].flatten()
             mu_sequence = mu_sequence[-self.lstm_net.lstm_look_back_len :]
             var_sequence = var_sequence[-self.lstm_net.lstm_look_back_len :]
             self.lstm_output_history.mu = mu_sequence

--- a/src/canari/model.py
+++ b/src/canari/model.py
@@ -1805,8 +1805,8 @@ class Model:
 
         if self.lstm_net and self.lstm_net.smooth and self.lstm_net.num_samples > 1:
             mu_zo_smooth, var_zo_smooth = self.lstm_net.smoother()
-            mu_sequence = mu_zo_smooth[:,: self.lstm_net.lstm_infer_len].flatten()
-            var_sequence = var_zo_smooth[:,: self.lstm_net.lstm_infer_len].flatten()
+            mu_sequence = mu_zo_smooth[0,: self.lstm_net.lstm_infer_len].flatten()
+            var_sequence = var_zo_smooth[0,: self.lstm_net.lstm_infer_len].flatten()
             mu_sequence = mu_sequence[-self.lstm_net.lstm_look_back_len :]
             var_sequence = var_sequence[-self.lstm_net.lstm_look_back_len :]
             self.lstm_output_history.mu = mu_sequence

--- a/src/canari/optimizer.py
+++ b/src/canari/optimizer.py
@@ -46,6 +46,7 @@ class Optimizer:
         back_end (str, optional): "ray". Using the external library Ray for optimization.
         num_startup_trials (int, optional): Number of start up trial when using TPE sampling.
             Defaults to 20.
+        max_concurrent (int, optional): Maximum number of trials to run in parallel. Defaults to 1.
 
     Attributes:
         model_optim :
@@ -65,6 +66,7 @@ class Optimizer:
         algorithm: Optional[str] = "TPE",  # "TPE" or "random"
         back_end: Optional[str] = "ray",
         num_startup_trials: Optional[int] = 20,
+        max_concurrent: Optional[int] = 1,
     ):
         """
         Initialize the Optimizer.
@@ -82,6 +84,7 @@ class Optimizer:
         self._algorithm = algorithm
         self._backend = back_end
         self._num_startup_trials = num_startup_trials
+        self._max_concurrent = max_concurrent
 
     def objective(self, config: Dict) -> Dict:
         """
@@ -151,6 +154,7 @@ class Optimizer:
                 self.objective,
                 config=search_config,
                 num_samples=1,
+                max_concurrent_trials=self._max_concurrent,
                 verbose=0,
                 raise_on_failed_trial=False,
                 callbacks=[custom_logger],
@@ -172,6 +176,7 @@ class Optimizer:
                         metric="metric", mode=self._mode, sampler=sampler
                     ),
                     num_samples=self._num_optimization_trial,
+                    max_concurrent_trials=self._max_concurrent,
                     verbose=0,
                     raise_on_failed_trial=False,
                     callbacks=[custom_logger],
@@ -183,6 +188,7 @@ class Optimizer:
                     config=search_config,
                     num_samples=self._num_optimization_trial,
                     scheduler=scheduler,
+                    max_concurrent_trials=self._max_concurrent,
                     verbose=0,
                     raise_on_failed_trial=False,
                     callbacks=[custom_logger],

--- a/src/canari/skf.py
+++ b/src/canari/skf.py
@@ -655,7 +655,7 @@ class SKF:
                 )
 
         return transition_coef
-    
+
     def _states_intervention(self, delta_mu, delta_var):
         """
         States intervention.
@@ -670,15 +670,15 @@ class SKF:
         #     for transition_model in self.model.values():
         #         transition_model.mu_states = transition_model.mu_states + delta_mu
         #         transition_model.var_states = transition_model.var_states + delta_var
-                
+
         # else:
         #     raise ValueError(
         #         "Incorrect mu and/or var dimension for inverventions."
         #     )
         for transition_model in self.model.values():
             transition_model._states_intervention(delta_mu, delta_var)
-        
-    def _transition_matrix_interv(self, delta_mu: list, delta_var:list, value:float):
+
+    def _transition_matrix_interv(self, delta_mu: list, delta_var: list, value: float):
         """
         Transition matrix intervention.
         """
@@ -1320,6 +1320,7 @@ class SKF:
         slope_anomaly: Optional[float] = None,
         anomaly_start: Optional[float] = 0.33,
         anomaly_end: Optional[float] = 0.66,
+        synthetic_data: Optional[dict] = None,
     ) -> Tuple[float, float]:
         """
         Add synthetic anomalies to orginal data, use Switching Kalman filter to detect those
@@ -1337,54 +1338,59 @@ class SKF:
             slope_anomaly (Optional[float]): Magnitude of the anomaly slope.
             anomaly_start (Optional[float]): Fractional start position of anomaly. Defaults to 0.33.
             anomaly_end (Optional[float]): Fractional end position of anomaly. Defaults to 0.66.
+            synthetic_data (Optional[dict]): Pre-generated synthetic anomaly data. If None,
+                                        it is generated from `data` using `num_anomaly`,
+                                        `slope_anomaly`, `anomaly_start`, and `anomaly_end`.
 
         Returns:
-            Tuple(detection_rate, false_rate, false_alarm_train):
+            Tuple(detection_rate, num_false_alarm):
                 detection_rate (float): # time series where anomalies detected / # total synthetic time series with anomalies added.
-                false_rate (float): # time series where anomalies NOT detected / # total synthetic time series with anomalies added.
-                false_alarm_train (str): 'Yes' if any alarm during training data.
+                num_false_alarm (int): # timesteps on the original clean data where the filter marginal abnormal probability exceeds `threshold`.
         """
 
         num_timesteps = len(data["y"])
         num_anomaly_detected = 0
         num_false_alarm = 0
-        false_alarm_train = "No"
 
-        synthetic_data = DataProcess.add_synthetic_anomaly(
-            data,
-            num_samples=num_anomaly,
-            slope=[slope_anomaly],
-            anomaly_start=anomaly_start,
-            anomaly_end=anomaly_end,
-        )
+        if synthetic_data is None:
+            synthetic_data = DataProcess.add_synthetic_anomaly(
+                data,
+                num_samples=num_anomaly,
+                slope=[-slope_anomaly, slope_anomaly],
+                anomaly_start=anomaly_start,
+                anomaly_end=anomaly_end,
+            )
+        total_anomalies = len(synthetic_data)
 
-        filter_marginal_abnorm_prob, _ = self.filter(data=data)
+        clean_filter_marginal_abnorm_prob, _ = self.filter(data=data)
         self.load_initial_states()
 
-        # Check false alarm in the training set
-        if any(filter_marginal_abnorm_prob > threshold):
-            false_alarm_train = "Yes"
+        # Quantify pre-anomaly false alarms on the original clean data
+        num_false_alarm = int(np.sum(clean_filter_marginal_abnorm_prob > threshold))
 
         # Iterate over data with synthetic anomalies
-        for i in range(0, num_anomaly):
+        for i in range(total_anomalies):
             filter_marginal_abnorm_prob, _ = self.filter(data=synthetic_data[i])
-            window_start = synthetic_data[i]["anomaly_timestep"]
+            window_start = int(synthetic_data[i]["anomaly_timestep"])
 
             if max_timestep_to_detect is None:
                 window_end = num_timesteps
             else:
-                window_end = window_start + max_timestep_to_detect
-            if any(filter_marginal_abnorm_prob[window_start:window_end] > threshold):
+                window_end = window_start + int(max_timestep_to_detect)
+            detection_indices = np.flatnonzero(
+                filter_marginal_abnorm_prob[window_start:window_end] > threshold
+            )
+            if detection_indices.size > 0:
                 num_anomaly_detected += 1
-            if any(filter_marginal_abnorm_prob[:window_start] > threshold):
-                num_false_alarm += 1
 
             self.load_initial_states()
 
-        detection_rate = num_anomaly_detected / num_anomaly
-        false_rate = num_false_alarm / num_anomaly
+        detection_rate = num_anomaly_detected / total_anomalies
 
-        return detection_rate, false_rate, false_alarm_train
+        return (
+            detection_rate,
+            num_false_alarm,
+        )
 
     def objective(
         self,

--- a/src/canari/skf.py
+++ b/src/canari/skf.py
@@ -1392,11 +1392,11 @@ class SKF:
         false_rate,
         anm_magnitude,
         detection_rate_cdf_mean: Optional[float] = 0.5,
-        detection_rate_cdf_std: Optional[float] = 0.5,
+        detection_rate_cdf_std: Optional[float] = 0.2,
         false_rate_cdf_median: Optional[float] = 0.1,  # [false alarms/year]
         false_rate_cdf_shape: Optional[float] = 0.2,  # [false alarms/year]
-        anm_mag_cdf_median: Optional[float] = 0.3,  # [unit/year]
-        anm_mag_cdf_shape: Optional[float] = 0.4,  # [unit/year]
+        anm_mag_cdf_median: Optional[float] = 0.2,  # [unit/year]
+        anm_mag_cdf_shape: Optional[float] = 0.6,  # [unit/year]
     ) -> int:
         """
         Calculate the metric that is used when optimizing for SKF's parameters.

--- a/src/canari/skf.py
+++ b/src/canari/skf.py
@@ -11,7 +11,7 @@ On time series data, this model can:
 
 """
 
-from typing import Tuple, Dict, Optional
+from typing import Tuple, Dict, List, Optional
 import copy
 import numpy as np
 from pytagi import metric
@@ -1320,7 +1320,7 @@ class SKF:
         slope_anomaly: Optional[float] = None,
         anomaly_start: Optional[float] = 0.33,
         anomaly_end: Optional[float] = 0.66,
-        synthetic_data: Optional[dict] = None,
+        synthetic_data: Optional[List[dict]] = None,
     ) -> Tuple[float, float]:
         """
         Add synthetic anomalies to orginal data, use Switching Kalman filter to detect those
@@ -1338,9 +1338,11 @@ class SKF:
             slope_anomaly (Optional[float]): Magnitude of the anomaly slope.
             anomaly_start (Optional[float]): Fractional start position of anomaly. Defaults to 0.33.
             anomaly_end (Optional[float]): Fractional end position of anomaly. Defaults to 0.66.
-            synthetic_data (Optional[dict]): Pre-generated synthetic anomaly data. If None,
-                                        it is generated from `data` using `num_anomaly`,
-                                        `slope_anomaly`, `anomaly_start`, and `anomaly_end`.
+            synthetic_data (Optional[List[dict]]): Pre-generated list of synthetic anomaly
+                                        series (each a dict with an "anomaly_timestep" key).
+                                        If None, it is generated from `data` using
+                                        `num_anomaly`, `slope_anomaly`, `anomaly_start`,
+                                        and `anomaly_end`.
 
         Returns:
             Tuple(detection_rate, num_false_alarm):
@@ -1350,7 +1352,6 @@ class SKF:
 
         num_timesteps = len(data["y"])
         num_anomaly_detected = 0
-        num_false_alarm = 0
 
         if synthetic_data is None:
             synthetic_data = DataProcess.add_synthetic_anomaly(


### PR DESCRIPTION
## Description

This PR improves the synthetic anomaly detection workflow in `skf.py` and adds parallelism control to the `optimizer.py`

## Changes Made

`skf.detect_synthetic_anomaly()`
New `synthetic_data` argument to pass pre-generated anomaly series, enabling reproducible benchmarks; falls back to internal generation when None.
Internal generation now uses symmetric slopes `[-slope_anomaly, slope_anomaly]` instead of only positive.
Return signature changed from `(detection_rate, false_rate, false_alarm_train)` to `(detection_rate, num_false_alarm)`, where `num_false_alarm` is the count of timesteps on the clean data exceeding threshold (previously only a Yes/No flag).
Removed redundant per-series pre-window false-alarm counting.

`skf.objective()`
objective defaults retuned: `detection_rate_cdf_std` 0.5→0.2, `anm_mag_cdf_median` 0.3→0.2, `anm_mag_cdf_shape` 0.4→0.6.

`optimizer.py`
Added `max_concurrent` parameter (default 1) wired into all three Ray Tune `tune.run` calls via `max_concurrent_trials`, allowing users to cap parallel trials.

`examples/benchmark/`
Updated `BM_2step_optim.py`, `BM_cdf_obj.py`, and `BM_cdf_obj_fix_skf_param.py` to match the new return signature.

## Related Issue(s)

NA

## Checklist

- [x] I have followed the project's coding conventions and style guidelines.
- [x] I have updated or added documentation where necessary.
- [x] I have rebased my branch onto the latest `main` (or relevant) branch.
- [x] I have verified that no sensitive data, plots, or files are included.
- [x] I have run all previous examples successfully, with no errors.
- [x] I have tested my changes locally using the following commands/tests:

```shell
pytest
```

## Notes for Reviewers
To check you can run any of `BM_2step_optim.py`, `BM_cdf_obj.py`, and `BM_cdf_obj_fix_skf_param.py` with cdf objective function.
